### PR TITLE
SDQ 2072: Add default low-level threshold to 100 Gig Optical components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ setuptools*
 *EGG-INFO*
 *dist
 .svn/
+
+.vscode/
+.vstags
+.code-workspace

--- a/README.rst
+++ b/README.rst
@@ -210,6 +210,16 @@ Change History
     models.  Fixed bug in RenderServer.py so the command will work on devices
     on remote collectors.
 
+* 1.15
+
+  * Added support for more 100 Gig hardware
+  * Added checks for AdminState to ignore out-of-service components
+  * Changed component modeling for OTU ports to continue search after first port on a card
+  * Added new data/graphs:
+    * Added Rx, Tx, and SNR to OTU100Gig
+    * Added Rx to Optical100Gig
+    * Added SNR, FEC to Transponders
+
 Known Issues
 ===========
 

--- a/README.rst
+++ b/README.rst
@@ -213,15 +213,29 @@ Change History
 * 1.15
 
   * Added support for more 100 Gig hardware
+
   * Added checks for AdminState to ignore out-of-service components
+
   * Changed component modeling for OTU ports to continue search after first port on a card
+
   * Added new data/graphs:
+
     * Added Rx, Tx, and SNR to OTU100Gig
+
     * Added Rx to Optical100Gig
+
     * Added SNR, FEC to Transponders
 
+* 1.16
+
+  * Removed checks for adminState when determining "in production" components
+
+* 1.17
+
+  * Added default low-level threshold to 100 Gig Optical components
+
 Known Issues
-===========
+============
 
 * Component templates attempt to graph data that may not be available from
   some components.  This may result in debug level events for SNMP variables

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/AdvaMibTypes.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/AdvaMibTypes.py
@@ -1,0 +1,21 @@
+"""
+Code translations for defined types in ADVA-MIB
+"""
+
+class AssignmentState:
+    """
+    http://www.circitor.fr/Mibs/Html/A/ADVA-MIB.php#AssignmentState
+    """
+    UNDEFINED = 0
+    ASSIGNED = 1
+    UNASSIGNED = 2
+    NOT_ASSIGNABLE = 3
+
+
+class EquipmentState:
+    """
+    http://www.circitor.fr/Mibs/Html/A/ADVA-MIB.php#EquipmentState
+    """
+    UNDEFINED = 0
+    EQUIPPED = 1
+    UNEQUIPPED = 2

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/AdvaMibTypes.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/AdvaMibTypes.py
@@ -1,6 +1,21 @@
 """
-Code translations for defined types in ADVA-MIB
+Code translations for defined types in ADVA MIBs
 """
+
+class AdminState:
+    """
+    http://www.circitor.fr/Mibs/Html/A/ADVA-FSPR7-TC-MIB.php#FspR7AdminState
+    Translations assisted by browsing the Adva FSP Network Manager client.
+    """
+    UNDEFINED = 0
+    UNASSIGNED = 1
+    IN_SERVICE = 2
+    AUTO_IN_SERVICE = 3
+    OUT_OF_SERVICE_MANAGEMENT = 4
+    OUT_OF_SERVICE_MAINTENANCE = 5
+    DISABLED = 6
+    PRE_POST_SERVICE = 7
+
 
 class AssignmentState:
     """

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibCommon.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibCommon.py
@@ -46,7 +46,7 @@ class FSP3000R7MibCommon(SnmpPlugin):
 
         inventoryTable = entityTable = opticalIfDiagTable = False
         containsOPRModules = {}
-        gotCache, inventoryTable, entityTable, opticalIfDiagTable, \
+        gotCache, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, \
             containsOPRModules = getCache(device.id, self.name(), log)
         if not gotCache:
             log.debug('Could not get cache for %s' % self.name())

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibCommon.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibCommon.py
@@ -135,6 +135,6 @@ and 'VCH-1-7-N1' -> ' 1 7VCH N1'"""
         a = entityIndexAid.split('-',4)
         if len(a) < 3:
             return '000000000'
-        if entityIndexAid.startswith('MOD-') or entityIndexAid.startswith('FAN-'):
-            return "%03s%03s000000" % (a[1],a[2])
+        if entityIndexAid.startswith('MOD-') or entityIndexAid.startswith('FAN-') or entityIndexAid.startswith('MODC-') or entityIndexAid.startswith(FANC-)::
+            return "%03s%03s%03s000" % (a[1],a[2],a[0])
         return "%03s%03s%03s%03s" % (a[1],a[2],a[0],a[3])

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibPickle.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7MibPickle.py
@@ -5,7 +5,7 @@ from pprint import pformat
 def getCache (deviceId, modelerName, log):
     cache_file_name = '/tmp/%s.Adva_inventory_SNMP.pickle' % deviceId
 
-    inventoryTable = entityTable = opticalIfDiagTable = False
+    inventoryTable = entityTable = opticalIfDiagTable = adminStateTable = False
     cache_file_time = 0
 
     bad_cache = 0
@@ -15,6 +15,7 @@ def getCache (deviceId, modelerName, log):
         inventoryTable = cPickle.load(cache_file)
         entityTable = cPickle.load(cache_file)
         opticalIfDiagTable = cPickle.load(cache_file)
+        adminStateTable = cPickle.load(cache_file)
         cache_file_time = cPickle.load(cache_file)
         cache_file.close()
     except IOError,cPickle.PickleError:
@@ -23,16 +24,16 @@ def getCache (deviceId, modelerName, log):
 
     if bad_cache or cache_file_time < time.time() - 900:
         log.warn("Cached SNMP doesn't exist or is older than 15 minutes. You must include the modeler plugin FSP3000R7Device")
-        return False, inventoryTable, entityTable, opticalIfDiagTable, containsOPRModules
+        return False, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, containsOPRModules
 
     if not inventoryTable:
         log.warn('No SNMP inventoryTable response from %s %s',
                  deviceId, modelerName)
-        return False, inventoryTable, entityTable, opticalIfDiagTable, containsOPRModules
+        return False, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, containsOPRModules
     if not entityTable:
         log.warn('No SNMP entityTable response from %s for the %s plugin',
                  deviceId, modelerName)
-        return False, inventoryTable, entityTable, opticalIfDiagTable, containsOPRModules
+        return False, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, containsOPRModules
     else:
         log.debug('SNMP entityTable and inventoryTable responses received')
     # not all modules will respond to opticalIfDiagTable so don't return False
@@ -76,7 +77,7 @@ def getCache (deviceId, modelerName, log):
                 else:
                     containsOPRModules[parentIndexAid].append(entityIndex)
 
-    return True,inventoryTable,entityTable,opticalIfDiagTable,containsOPRModules
+    return True, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, containsOPRModules
 
 
 def __get_parent(log,childIndex,entityTable):

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7RamanMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/FSP3000R7RamanMib.py
@@ -48,7 +48,7 @@ class FSP3000R7RamanPortMib(SnmpPlugin):
         # cached data from device modeler
         inventoryTable = entityTable = opticalIfDiagTable = False
         containsOPRModules = {}
-        gotCache, inventoryTable, entityTable, opticalIfDiagTable, \
+        gotCache, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, \
             containsOPRModules = getCache(device.id, self.name(), log)
         if not gotCache:
             log.debug('Could not get cache for %s' % self.name())

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/FanModels.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/FanModels.py
@@ -8,4 +8,4 @@
 
 __doc__='Valid Fan component models'
 
-FanModels = [ 'FAN/9HU','FAN/PLUG-IN', 'FAN/Plug-In', 'FAN/1HU' ]
+FanModels = [ 'FAN/9HU','FAN/PLUG-IN', 'FAN/Plug-In', 'FAN/1HU', 'FTM-4' ]

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/NCUModels.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/NCUModels.py
@@ -8,4 +8,4 @@
 
 __doc__='Valid NCU component models'
 
-NCUModels = [ 'NCU-II', 'NCU-II-P', 'NCU' ]
+NCUModels = [ 'NCU-II', 'NCU-II-P', 'NCU','ECM-2' ]

--- a/ZenPacks/Merit/AdvaFSP3000R7/lib/PowerSupplyModels.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/lib/PowerSupplyModels.py
@@ -12,4 +12,4 @@ PowerSupplyModels = [ 'PSU/7HU-DC',   'PSU/7HU-AC',   'PSU/7HU-R-DC',
                       'PSU/9HU-DC',   'PSU/9HU-AC',   'PSU/1HU-R-AC',
                       'PSU/7HU-AC-800', 'PSU/7HU-DC-800', 'PSU/7HU-R-DC-HP',
                       'PSU/1HU-R-AC-200', 'PSU/1HU-R-DC-200',
-                      'PSU/X9HU-DC-800' ]
+                      'PSU/X9HU-DC-800', 'PSM-AC4', 'PSM-AC5', 'PSM-DC4' ]

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7ModuleMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7ModuleMib.py
@@ -57,7 +57,7 @@ class FSP3000R7ModuleMib(SnmpPlugin):
             inventoryUnitName = inventoryTable[entityIndex]['inventoryUnitName']
             if inventoryUnitName in FanorNCUorPSModels:
                 continue
-            if entityTable[entityIndex]['entityIndexAid'].startswith('MOD-'):
+            if entityTable[entityIndex]['entityIndexAid'].startswith('MOD-') or entityTable[entityIndex]['entityIndexAid'].startswith('MODC-'):
                 om = self.objectMap()
                 om.EntityIndex = int(entityIndex)
                 om.inventoryUnitName = inventoryUnitName

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7ModuleMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7ModuleMib.py
@@ -40,7 +40,7 @@ class FSP3000R7ModuleMib(SnmpPlugin):
 
         inventoryTable = entityTable = opticalIfDiagTable = False
         containsModules = {}
-        gotCache, inventoryTable, entityTable, opticalIfDiagTable, \
+        gotCache, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, \
             containsModules = getCache(device.id, self.name(), log)
         if not gotCache:
             log.debug('Could not get cache for %s' % self.name())

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7OTU100GMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7OTU100GMib.py
@@ -19,6 +19,7 @@ from re import match
 from Products.DataCollector.plugins.CollectorPlugin import SnmpPlugin, GetTableMap, GetMap
 from Products.DataCollector.plugins.DataMaps import ObjectMap
 from ZenPacks.Merit.AdvaFSP3000R7.lib.FSP3000R7MibPickle import getCache
+from ZenPacks.Merit.AdvaFSP3000R7.lib.FSP3000R7MibCommon import FSP3000R7MibCommon
 from ZenPacks.Merit.AdvaFSP3000R7.lib.AdvaMibTypes import AssignmentState
 from ZenPacks.Merit.AdvaFSP3000R7.lib.AdvaMibTypes import EquipmentState
 
@@ -26,8 +27,9 @@ from ZenPacks.Merit.AdvaFSP3000R7.lib.AdvaMibTypes import EquipmentState
 # Use SNMP data from Device Modeler in a cache file.  Can't be a PythonPlugin
 # since those run before any SnmpPlugin; device modeler is an PythonPlugin so
 # the cache file will be created before this is run.
-# Can't use FSP3000R7MibCommon since Muxsponder OTU ports don't respond to OPR
-class FSP3000R7OTU100GMib(SnmpPlugin):
+# Need to override FSP3000R7MibCommon.process() since some Muxsponder OTU ports
+# don't respond to OPR.
+class FSP3000R7OTU100GMib(FSP3000R7MibCommon):
 
     modname = 'ZenPacks.Merit.AdvaFSP3000R7.FSP3000R7OTU100Gig'
     relname = 'FSP3000R7OTU100G'
@@ -71,7 +73,12 @@ class FSP3000R7OTU100GMib(SnmpPlugin):
             bladeIndexAid = entityTable[bladeEntityIndex]['entityIndexAid']
             if not bladeInv in componentModels:
                 continue
-            log.info('found 100G Muxponder OTU matching model %s' % bladeInv)
+
+            # Skip blade if out of service
+            if not self._entity_is_in_service(bladeIndexAid, adminStateTable):
+                continue
+
+            log.info('found 100G Muxponder OTU matching model %s in module %s', bladeInv, bladeIndexAid)
     
             # find ports from entityContainedIn for 100G OTU entityIndex
             ports = self.__findPorts(log,bladeEntityIndex,entityTable)

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7OTU100GMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7OTU100GMib.py
@@ -56,7 +56,7 @@ class FSP3000R7OTU100GMib(SnmpPlugin):
         # cached data from device modeler
         inventoryTable = entityTable = opticalIfDiagTable = False
         containsOPRModules = {}
-        gotCache, inventoryTable, entityTable, opticalIfDiagTable, \
+        gotCache, inventoryTable, entityTable, opticalIfDiagTable, adminStateTable, \
             containsOPRModules = getCache(device.id, self.name(), log)
         if not gotCache:
             log.debug('Could not get cache for %s' % self.name())

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7OTU100GMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7OTU100GMib.py
@@ -43,8 +43,10 @@ class FSP3000R7OTU100GMib(SnmpPlugin):
                            '10TCC-PCTN-10G+100GC',
                            '10TCE-PCN-10G+100G',
                            '10TCE-PCN-10G+100G-GF',
+                           '10TCE-PCN-16GU+100G',
                            'WCC-PCTN-100GA',
-                           'WCC-PCTN-100GB']
+                           'WCC-PCTN-100GB',
+                           'MP-2B4CT']
 
         # SNMP table
         getdata, tabledata = results

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7Optical100GigMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7Optical100GigMib.py
@@ -41,7 +41,7 @@ class FSP3000R7Optical100GigMib(SnmpPlugin):
         for snmpIndex in tabledata['entityFacilityTable']:
             entityFacilityAidString = tabledata['entityFacilityTable']\
                                           [snmpIndex]['entityFacilityAidString']
-            if re.match('OTL\-\d+\-\d+\-N\-\d$',entityFacilityAidString):
+            if re.match('OTL\-\d+\-\d+\-N\-\d$',entityFacilityAidString) or re.match('OTL-\d+-\d+-C\d-\d$',entityFacilityAidString) :
                 om = self.objectMap()
                 om.title = entityFacilityAidString
                 om.id = self.prepId(entityFacilityAidString)

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7TransponderMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7TransponderMib.py
@@ -80,4 +80,5 @@ class FSP3000R7TransponderMib(FSP3000R7MibCommon):
                         '10TCE-PCN-10G+100G-GF',
                         '10TCE-PCN-10G+100G',
                         '8TCE-ESCON+2G5-V#',
-                        '8TCE-GLINK+2G5-V#' ]
+                        '8TCE-GLINK+2G5-V#',
+                        'MP-2B4CT' ]

--- a/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7TransponderMib.py
+++ b/ZenPacks/Merit/AdvaFSP3000R7/modeler/plugins/Adva/FSP3000R7TransponderMib.py
@@ -79,6 +79,7 @@ class FSP3000R7TransponderMib(FSP3000R7MibCommon):
                         '5TCE-PCTN-8GU+10GS-V#DC',
                         '10TCE-PCN-10G+100G-GF',
                         '10TCE-PCN-10G+100G',
+                        '10TCE-PCN-16GU+100G',
                         '8TCE-ESCON+2G5-V#',
                         '8TCE-GLINK+2G5-V#',
                         'MP-2B4CT' ]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.Merit.AdvaFSP3000R7"
-VERSION = "1.16"
+VERSION = "1.17"
 AUTHOR = "Merit Network, Inc."
 LICENSE = "GPLv2"
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.Merit']

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.Merit.AdvaFSP3000R7"
-VERSION = "1.15.0"
+VERSION = "1.16"
 AUTHOR = "Merit Network, Inc."
 LICENSE = "GPLv2"
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.Merit']

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.Merit.AdvaFSP3000R7"
-VERSION = "1.14.0"
-AUTHOR = "Russell Dwarshuis"
+VERSION = "1.15.0"
+AUTHOR = "Merit Network, Inc."
 LICENSE = "GPLv2"
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.Merit']
 PACKAGES = ['ZenPacks', 'ZenPacks.Merit', 'ZenPacks.Merit.AdvaFSP3000R7']


### PR DESCRIPTION
# Problem
After a recent ZenPack update to add input power graphs/data to 100 Gig Optical components, a corresponding threshold wasn't applied to generate Zenoss events when input power dropped.

# Solution
Copy the existing threshold from the "Transponder" component class into the "100G Muxsponder Optical" class. This will apply a default threshold of -270 (equivalent to -27.0 dBm) to these components.

# Testing
This has been tested by Merit Network Engineering and Software Development.